### PR TITLE
feat: Make mixins theme-ui-aware

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3013,6 +3013,20 @@
         "any-observable": "^0.3.0"
       }
     },
+    "@theme-ui/color": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@theme-ui/color/-/color-0.3.1.tgz",
+      "integrity": "sha512-Bgew6etspp087AdrKuMpcWjIQDQ8UTp28wtHCXgi1Ip5ClFn9i91DvaKgqXk9UwQJFL/IwydX8Bks/+u9tf0WA==",
+      "requires": {
+        "@theme-ui/css": "^0.3.1",
+        "polished": "^3.4.1"
+      }
+    },
+    "@theme-ui/css": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@theme-ui/css/-/css-0.3.1.tgz",
+      "integrity": "sha512-QB2/fZBpo4inaLHL3OrB8NOBgNfwnj8GtHzXWHb9iQSRjmtNX8zPXBe32jLT7qQP0+y8JxPT4YChZIkm5ZyIdg=="
+    },
     "@types/anymatch": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/@types/anymatch/-/anymatch-1.3.1.tgz",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   },
   "homepage": "https://react-focus-utils.netlify.com",
   "dependencies": {
-    "polished": "^3.4.4",
+    "@theme-ui/color": "^0.3.1",
     "prop-types": "^15.6.2"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "build": "npm run build:cjs && npm run build:esm",
     "build:cjs": "NODE_ENV=cjs rollup -c -o dist/index.js",
     "build:esm": "NODE_ENV=esm rollup -c -o dist/index.m.js",
-    "prepublish": "npm run build",
+    "prepare": "npm run build",
     "pretest": "npm run lint",
     "test": "echo \"Error: no test specified\" && exit 0",
     "lint": "eslint .",

--- a/src/mixins.js
+++ b/src/mixins.js
@@ -1,14 +1,14 @@
-import { transparentize } from 'polished'
+import { transparentize } from '@theme-ui/color'
 
 /**
  * Mixin to generate consistent box-shadow rule for focus rings and selections
  */
-export function focusBoxShadow(color, hasInset = false) {
+export const focusBoxShadow = color => (t = {}) => {
+  // Check if it's a props object or the theme
+  // theme-ui provides theme as an argument where styled-system uses props.theme
+  let theme = t.theme || t
   return {
-    boxShadow: `
-        0 0 0 0.2em ${transparentize(0.75, color)}
-        ${hasInset ? `, 0 0 0 1px ${color} inset` : ''}
-        `
+    boxShadow: `0 0 0 0.2em ${transparentize(color, 0.75)(theme)}`
   }
 }
 
@@ -23,7 +23,7 @@ export function focusBoxShadow(color, hasInset = false) {
  *   }
  * `
  */
-export function focusRingStyles(color, disabled = false) {
+export const focusRingStyles = (color, disabled = false) => (theme = {}) => {
   if (disabled) {
     return {
       outline: 'none'
@@ -33,7 +33,7 @@ export function focusRingStyles(color, disabled = false) {
     outline: 'none',
     borderColor: color,
     transition: 'box-shadow .25s',
-    ...focusBoxShadow(color)
+    ...focusBoxShadow(color)(theme)
   }
 }
 
@@ -46,17 +46,17 @@ export function focusRingStyles(color, disabled = false) {
  *   ${focusRing('red')}
  * `
  */
-export function focusRing(color, disabled = false, hover = false) {
+export const focusRing = (color, disabled = false, hover = false) => (theme = {}) => {
   const baseStyles = {
     '.js-focus-visible &:focus:not(.focus-visible)': {
       outline: 0
     },
-    '&.focus-visible': focusRingStyles(color, disabled)
+    '&.focus-visible': focusRingStyles(color, disabled)(theme)
   }
   if (hover) {
     return {
       ...baseStyles,
-      '&:hover:not(:disabled)': focusRingStyles(color, disabled)
+      '&:hover:not(:disabled)': focusRingStyles(color, disabled)(theme)
     }
   }
   return baseStyles

--- a/src/mixins.md
+++ b/src/mixins.md
@@ -35,15 +35,25 @@ const Button = styled('button')`
 Can be used separately to add consistent styles to other elements
 
 ```javascript
-import styled from 'styled-components'
+import styled, { ThemeProvider } from 'styled-components'
 import { focusBoxShadow } from './'
+
+const theme = {
+  colors: {
+    token: '#fc0'
+  }
+}
 
 const Example = styled('div')`
   padding: 10px;
-  ${focusBoxShadow('blue', true)}
+  border: 1px solid;
+  border-color: ${props => props.theme.colors.token};
+  ${focusBoxShadow('token')}
 `
 
-;<Example>Box with box-shadow "focus" effect</Example>
+;<ThemeProvider theme={theme}>
+  <Example>Box with box-shadow "focus" effect</Example>
+</ThemeProvider>
 ```
 
 ### `disabled`


### PR DESCRIPTION
BREAKING CHANGE: Removed second argument `hasInset` from `focusBoxShadow` mixin