### PR TITLE
Add focus within ts type definition

### DIFF
--- a/.changeset/new-goats-brake.md
+++ b/.changeset/new-goats-brake.md
@@ -1,0 +1,5 @@
+---
+'@component-driven/react-focus-within': patch
+---
+
+Add missing type definitions file for `FocusWithin` component.

--- a/packages/react-focus-within/src/index.d.ts
+++ b/packages/react-focus-within/src/index.d.ts
@@ -1,0 +1,16 @@
+import React from 'react'
+
+type RenderProps = (props: {
+  focused: boolean;
+  getRef: React.MutableRefObject<HTMLElement>;
+}) => React.ReactNode
+
+export interface Props {
+  children: React.ReactNode | RenderProps;
+  onBlur?: (event: React.MouseEvent<HTMLElement>) => void;
+  onFocus?: (event: React.MouseEvent<HTMLElement>) => void;
+}
+
+declare class FocusWithin extends React.Component<Props, any> {}
+
+export default FocusWithin


### PR DESCRIPTION
This PR adds the missing type definition files for `FocusWithin` component.