### PR TITLE
Fix typo in using with css in js libs docs

### DIFF
--- a/.changeset/large-pans-mix.md
+++ b/.changeset/large-pans-mix.md
@@ -1,0 +1,5 @@
+---
+'@component-driven/react-focus-within': patch
+---
+
+Fix typo in 'Using with CSS-in-JS libs' section for '@component-driven/react-focus-within' package.

--- a/packages/react-focus-within/Readme.md
+++ b/packages/react-focus-within/Readme.md
@@ -64,7 +64,7 @@ If you want to react to the focus change, use function as a children pattern. Wh
 
 ## Using with CSS-in-JS libs
 
-If you're using a CSS-in-JS library like [styled-components](https://www.styled-components.com) you need to pass a ref using `innerRef` prop. You can use `getRef` function from the parameters.
+If you're using a CSS-in-JS library like [styled-components](https://www.styled-components.com) you need to pass a ref using `ref` prop. You can use `getRef` function from the parameters.
 
 ```js static
 ;({ focused: Boolean, getRef: Function }) => React.Element
@@ -91,7 +91,7 @@ const StyledBox = styled('div')`
   }}
 >
   {({ focused, getRef }) => (
-    <StyledBox innerRef={getRef} focused={focused}>
+    <StyledBox ref={getRef} focused={focused}>
       <input
         type="text"
         placeholder="Click to activate first input"


### PR DESCRIPTION
Fix typo in 'Using with CSS-in-JS libs' section.